### PR TITLE
Fix protocol prefix

### DIFF
--- a/src/axios.js
+++ b/src/axios.js
@@ -40,7 +40,7 @@ const buildRequest = (url, action, args) => {
 export default {
     install(vue, options = {}) {
         if (options.setCroudDefaults) {
-            axios.defaults.baseURL = `//${gateway_url}`
+            axios.defaults.baseURL = `${gateway_url.includes('https://') ? '' : '//'}${gateway_url}`
             axios.defaults.headers.common.Authorization = `Bearer ${localStorage.getItem('jwt')}`
             axios.defaults.paramsSerializer = params => qs.stringify(params, { arrayFormat: 'brackets' })
         }

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ new Vue({
         Vue.use(axios, { setCroudDefaults: true })
         Vue.use(VueEcho, {
             broadcaster: 'socket.io',
-            host: `//${node_gateway_url}`,
+            host: `${node_gateway_url.includes('https://') ? '' : '//'}${node_gateway_url}`,
             auth: {
                 headers: {
                     Authorization: `Bearer ${localStorage.getItem('jwt')}`,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -14,7 +14,7 @@ export default {
         Vue.use(VueMoment)
         Vue.use(VueEcho, {
             broadcaster: 'socket.io',
-            host: `//${node_gateway_url}`,
+            host: `${node_gateway_url.includes('https://') ? '' : '//'}${node_gateway_url}`,
             auth: {
                 headers: {
                     Authorization: `Bearer ${localStorage.getItem('jwt')}`,


### PR DESCRIPTION
Simple get out jail free for the anything being locally developed that needs to connect with anything over SSL. Still defaults to '//' prefix if none defined.

@digitalbanana was this the two places you were changing?