### PR TITLE
WIP: Il8n

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "socket.io-client": "^2.0.4",
     "url-template": "^2.0.8",
     "vue-echo": "^1.0.1",
+    "vue-i18n": "^7.4.2",
     "vue-moment": "^2.1.0"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,7 +22,7 @@
                 <div id="main-content-body" v-bind:class="classList">
                     <notifications-sidebar/>
                     <slot v-if="globalPermission" name="content">
-                        <h1 class="ui heading">Test</h1>
+                        <h1 class="ui heading">{{ $t('message.hello') }}</h1>
                     </slot>
                     <slot v-else name="denied">
                         <div class="ui basic very padded secondary permissions-denied segment">

--- a/src/il8n/base.js
+++ b/src/il8n/base.js
@@ -1,0 +1,7 @@
+export default {
+    en: {
+        message: {
+            hello: 'hello world',
+        },
+    },
+}

--- a/src/il8n/base.js
+++ b/src/il8n/base.js
@@ -1,7 +1,7 @@
 export default {
     en: {
         message: {
-            hello: 'hello world',
+            hello: 'Test',
         },
     },
 }

--- a/src/il8n/index.js
+++ b/src/il8n/index.js
@@ -1,0 +1,8 @@
+import { defaultsDeep } from 'lodash'
+import base from './base'
+import notifications from './notifications'
+
+export default defaultsDeep(
+    base,
+    notifications,
+)

--- a/src/il8n/notifications.js
+++ b/src/il8n/notifications.js
@@ -1,0 +1,7 @@
+export default {
+    en: {
+        notifications: {
+            empty: 'No new notifications',
+        },
+    },
+}

--- a/src/main.js
+++ b/src/main.js
@@ -4,10 +4,12 @@ import Vue from 'vue'
 import VueSemantic from 'croud-vue-semantic'
 import VueMoment from 'vue-moment'
 import VueEcho from 'vue-echo'
+import VueI18n from 'vue-i18n'
 
 import App from './App'
 import store from './store'
 import axios from './axios'
+import messages from './il8n'
 
 import '../semantic/dist/semantic.min'
 import '../semantic/dist/semantic.min.css'
@@ -17,9 +19,16 @@ window.io = require('socket.io-client')
 Vue.config.productionTip = false
 Vue.use(VueSemantic)
 Vue.use(VueMoment)
+Vue.use(VueI18n)
+
+const i18n = new VueI18n({
+    locale: 'en',
+    messages,
+})
 
 /* eslint-disable no-new */
 new Vue({
+    i18n,
     el: '#app',
     template: '<App/>',
     components: { App },

--- a/test/unit/specs/App.spec.js
+++ b/test/unit/specs/App.spec.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
+import VueI18n from 'vue-i18n'
 
 // import _ from 'lodash'
 import localforage from 'localforage'
@@ -8,8 +9,15 @@ import localstorage from 'localstorage'
 
 import App from '../../../src/App'
 import Store from '../../../src/store'
+import messages from '../../../src/il8n'
+
+Vue.use(VueI18n)
 
 const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjVlNjE0OWQyMjgzYzBhZmEwOWJiZDJiYzE3ZDA2ZDk1ODRjZDcxN2E5M2QwNjhiYTU0NmIyNGI3ODE3MDI2NTY1MjBjYjZiYjFkMTk1MmVlIn0.eyJhdWQiOiJnYXRld2F5LWlyZWxhbmQiLCJqdGkiOiI1ZTYxNDlkMjI4M2MwYWZhMDliYmQyYmMxN2QwNmQ5NTg0Y2Q3MTdhOTNkMDY4YmE1NDZiMjRiNzgxNzAyNjU2NTIwY2I2YmIxZDE5NTJlZSIsImlhdCI6MTUwMDk3NDMwNSwibmJmIjoxNTAwOTc0MzA1LCJleHAiOjE1MDEyMzM1MDUsInN1YiI6IjIxMTciLCJzY29wZXMiOltdfQ.SGcw02bTra8PkAY1k3jbTWWh6kQwxP9CxnOU8wVzyXbVeevSZ9DomHMmMTBKTBajhNOvsrdFqROJj8nAO4NLqoroNAsK8syS1ytKHDmzFtOjDLxx4rEnJgs8jANVPeFAd8EMSD96I6Rqt0v0BmohjJp5H7WXGvvO8MdPsPSVPTW2OVaLjIXM6b8Ra-X0CV-zyeh48ynYQ_dXdIXssZM8s0i-iuDfQPcZwE8j4Yenq-Omm6tkf2ScG5AzS_3M61svsU09wXpBPvsvXsEFOF74Cjy1Sli0hUg90Bz9bX1uW983Dl3VDcsVqBfufR8fqJwjxmSotZUN8pKLUlXoTYD7LHj3UKluZlVDXMHd_J8l659X5M8tH18jIU3E26vz96LaosGJ6yB4aKQsKQAySrEHiB4F_PJOBi09hh1jLvPOi6e_XCdSieml3hZiGid8zEoR77yxxQsBHGY4YAda5Fb93mKy8ckCKbCjXybahrGleq1GI28f3ZwuW_RdhgjMuLIE6zE8mZrbZXNB8dvO7zfgPq1ty07gvU0Tbmf4Kggtr7E3_xKUOBFS2etcjUHDGloS_ql7pEiu3OwF4uCU1pdCA14pJz41EiW_gYfy5VDykMukRkYqJn2AddNmL4dKVUmeB7oo79W73TUSt7SwC05LSPCRtID-kQ7vQyCvG3MwQw4'
+const i18n = new VueI18n({
+    locale: 'en',
+    messages,
+})
 
 describe('App.vue', () => {
     let $vm
@@ -18,6 +26,7 @@ describe('App.vue', () => {
         Vue.use(Vuex)
         Vue.use(localstorage)
         $vm = new Vue({
+            i18n,
             components: {
                 App,
             },
@@ -56,6 +65,7 @@ describe('App.vue', () => {
 
         test('empty template', async () => {
             $vm = new Vue({
+                i18n,
                 components: {
                     App,
                 },
@@ -82,6 +92,7 @@ describe('App.vue', () => {
 
         test('custom layout', async () => {
             $vm = new Vue({
+                i18n,
                 components: {
                     App,
                 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10803,6 +10803,10 @@ vue-hot-reload-api@^2.0.11:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.1.0.tgz#9ca58a6e0df9078554ce1708688b6578754d86de"
 
+vue-i18n@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-7.4.2.tgz#ef954f80898bb3609f132f77d51a7053379e03b2"
+
 vue-loader@^11.3.4:
   version "11.3.4"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-11.3.4.tgz#65e10a44ce092d906e14bbc72981dec99eb090d2"


### PR DESCRIPTION
This is a proposal that I want to get some feedback on, both in terms of implementation and the idea itself.

I want to start a translation first approach to the text on our frontend dev, this has very little benefit in the short term, but we will be glad we took these vitamins in the future.

https://kazupon.github.io/vue-i18n/en/

Not only will it allow us to expand to show different locales in the future but it will also centralise our language definitions and lexicon, promoting consistency across the product. This package also has some nice helpers for [pluralisation](https://kazupon.github.io/vue-i18n/en/pluralization.html), [number formatting](https://kazupon.github.io/vue-i18n/en/number.html), etc...

This will mean that we will no longer add any free text to our Vue templates, instead we use the `$t` method everywhere and add a new definition to a JSON structure at either a package or product level. This may be a pain to start with but imagine a world where we define common error messages once and don't have to worry about how many places we have to update if the wording in the spec changes. 

```html
<p class="bad">Boo!!</p>
<p class="good">{{ $t('message.yay') }}</p>
```

```js
{
  en: {
    message: {
      yay: 'Yay!!'
    },
  },
}
```

I will lead by example and update all of the text in our styleguide and croud-layout to use this approach if we feel that it is worth the effort.

Let me know your thoughts.