### PR TITLE
Translation factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Vue.use(CroudLayout, { store, noLegacyAuth: true })
 ```
 
 ## il8n
-croud-layout uses a translation first approach to it's text declaration and requires that you add some extra config to your project before using this plugin.
+croud-layout uses a translation first approach to its text declaration and requires that you add some extra config to your project before using this plugin.
 
 We use the [vue-il8n](https://github.com/kazupon/vue-i18n/) and you can find their docs [here](https://kazupon.github.io/vue-i18n/en/)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,45 @@ You can pass an additional option to disable legacy SSO auth
 ```js
 Vue.use(CroudLayout, { store, noLegacyAuth: true })
 ```
+
+## il8n
+croud-layout uses a translation first approach to it's text declaration and requires that you add some extra config to your project before using this plugin.
+
+We use the [vue-il8n](https://github.com/kazupon/vue-i18n/) and you can find their docs [here](https://kazupon.github.io/vue-i18n/en/)
+
+### Basic usage
+This package includes a translation factory which can be easily added to your project.
+```js
+/* Main.js */
+...
+import { translationFactory } from 'croud-layout/src/translation'
+...
+
+const i18n = translationFactory()
+new Vue({
+    i18n,
+    ...
+})
+```
+
+### Package translation
+By default, the translation factory will load a base set of translations. You can pass in additional translations as the first argument of the translation factory.
+
+```js
+const i18n = translationFactory({
+    en: {
+        custom: {
+            test: 'test string',
+        },
+    },
+})
+```
+
+### Set locale
+You can set the locale with the second argument of the translation factory.
+```js
+const i18n = translationFactory({}, 'ja')
+```
 ## Axios plugin
 A drop in replacement for vue-resource
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,12 +4,11 @@ import Vue from 'vue'
 import VueSemantic from 'croud-vue-semantic'
 import VueMoment from 'vue-moment'
 import VueEcho from 'vue-echo'
-import VueI18n from 'vue-i18n'
 
 import App from './App'
 import store from './store'
 import axios from './axios'
-import messages from './il8n'
+import { translationFactory } from './translation'
 
 import '../semantic/dist/semantic.min'
 import '../semantic/dist/semantic.min.css'
@@ -19,12 +18,8 @@ window.io = require('socket.io-client')
 Vue.config.productionTip = false
 Vue.use(VueSemantic)
 Vue.use(VueMoment)
-Vue.use(VueI18n)
 
-const i18n = new VueI18n({
-    locale: 'en',
-    messages,
-})
+const i18n = translationFactory()
 
 /* eslint-disable no-new */
 new Vue({

--- a/src/translation.js
+++ b/src/translation.js
@@ -1,0 +1,16 @@
+import Vue from 'vue'
+import VueI18n from 'vue-i18n'
+import { defaultsDeep } from 'lodash'
+
+import messages from './il8n'
+
+Vue.use(VueI18n)
+
+/* eslint-disable import/prefer-default-export */
+export function translationFactory(projectMessages = {}, locale = 'en') {
+    return new VueI18n({
+        locale,
+        fallbackLocale: 'en',
+        messages: defaultsDeep(messages, projectMessages),
+    })
+}


### PR DESCRIPTION
Leading on from #17, I believe that this would be the quickest and easiest way to get the il8n up and running in our projects.

I have built a translation factory that will help remove some repetitive bootstrapping from our projects. This will include sensible defaults for locale, fallback locale and will preload the base il8n config that will power the translations for this layout and help centralise product wide strings.

I have updated the readme to reflect these changes.