### PR TITLE
Custom moment instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "croud-layout",
   "main": "src/plugin.js",
-  "version": "1.12.0-4",
+  "version": "1.12.0-5",
   "description": "A Vue.js project",
   "author": "Brock <brock.reece@croud.co.uk>",
   "private": false,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -14,7 +14,10 @@ window.io = require('socket.io-client')
 export default {
     install(Vue, options) {
         Vue.component('croud-layout', croudLayout)
-        Vue.use(VueMoment)
+        Vue.use(VueMoment, {
+            moment: options.moment || false,
+        })
+
         Vue.use(VueEcho, {
             broadcaster: 'socket.io',
             host: `${node_gateway_url.includes('https://') ? '' : '//'}${node_gateway_url}`,


### PR DESCRIPTION
Allow users to pass through a custom version of moment to vue-moment, this will allow us to pass through supersets of moment, such as moment timezone and not add the additional bloat to our package bundle.

**Proposed usage:**
When installing the `CroudLayout` plugin, we can pass in an additional option for moment.
```js
// main.js
import moment from 'moment-timezone'
...
Vue.use(CroudLayout, { store, moment })
```

I will merge this into the websocket branch so it can be merged and tested along with the journals project.