### PR TITLE
Legacy nav

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/package.json
+++ b/package.json
@@ -129,5 +129,11 @@
     "setupFiles": [
       "<rootDir>/test/unit/mocks/localStorage.js"
     ]
+  },
+  "browserify": {
+    "transform": [
+      "vueify",
+      ["babelify", { "presets": ["es2015"] }]
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "croud-layout",
   "main": "src/plugin.js",
-  "version": "1.12.0",
+  "version": "1.13.0-0",
   "description": "A Vue.js project",
   "author": "Brock <brock.reece@croud.co.uk>",
   "private": false,
@@ -133,7 +133,14 @@
   "browserify": {
     "transform": [
       "vueify",
-      ["babelify", { "presets": ["es2015"] }]
+      [
+        "babelify",
+        {
+          "presets": [
+            "es2015"
+          ]
+        }
+      ]
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "croud-layout",
   "main": "src/plugin.js",
-  "version": "1.13.0-0",
+  "version": "1.13.0-1",
   "description": "A Vue.js project",
   "author": "Brock <brock.reece@croud.co.uk>",
   "private": false,

--- a/src/mixins/navigation.js
+++ b/src/mixins/navigation.js
@@ -175,12 +175,6 @@ export default {
         },
 
         items() {
-            const stashed = JSON.parse(localStorage.getItem(`main_navigation_${this.user.code}`))
-
-            if (stashed && stashed.data && stashed.data.list) {
-                return stashed.data.list
-            }
-
             return this.baseItems
         },
     },

--- a/test/unit/specs/__snapshots__/App.spec.js.snap
+++ b/test/unit/specs/__snapshots__/App.spec.js.snap
@@ -214,7 +214,73 @@ exports[`App.vue Cached data + jwt Full temnplate 1`] = `
       <div
         class="contained"
       >
-        <!--  -->
+        <div
+          class="contained scrollable navigation-block"
+        >
+          <div
+            class="footer"
+          >
+            <strong
+              class="expand-button"
+            >
+              <i
+                class="arrow circle double icon right"
+              />
+            </strong>
+          </div>
+          <ul
+            data-depth="1"
+          >
+            <li
+              class=""
+            >
+              <a
+                id="menuitem-dashboard"
+                href="/"
+              >
+                <i
+                  class="dashboard icon link-icon"
+                />
+                <span>
+                  Dashboard
+                </span>
+              </a>
+              <!--  -->
+            </li>
+            <li
+              class=""
+            >
+              <a
+                id="menuitem-mydetails"
+                href="/user/account"
+              >
+                <i
+                  class="user icon link-icon"
+                />
+                <span>
+                  My Details
+                </span>
+              </a>
+              <!--  -->
+            </li>
+            <li
+              class=""
+            >
+              <a
+                id="menuitem-helpcentre"
+                href="https://croud.freshdesk.com/support/solutions"
+              >
+                <i
+                  class="help circle outline icon link-icon"
+                />
+                <span>
+                  Help Centre
+                </span>
+              </a>
+              <!--  -->
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
     <div


### PR DESCRIPTION
We are looking to move the navigation menu on legacy over to use the Croud-layout components and mixin that builds the navigation items based on core permissions.

To appease browserify, we need to add some config to our `package.json` and remove the `.babelrc` from our NPM package else it isn't able to build.

As we will no longer be 'sharing' the menu structure between legacy and croud-layout, we don't need to read in the menu structure from localstorage. 

Also updates a previously broken snapshot test.