### PR TITLE
WIP: Proposed move to state machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "vue-echo": "^1.0.1",
     "vue-i18n": "^7.4.2",
     "vue-moment": "^2.1.0",
-    "vue-toasted": "^1.1.24"
+    "vue-toasted": "^1.1.24",
+    "xstate": "^3.1.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,12 @@
 <template>
   <div id="main-container">
-    <top-bar v-if="user.id && !suppressTopbar" :user="user"></top-bar>
-    <div v-if="loading" class="ui very padded basic center aligned loading-overlay segment">
+    <top-bar v-if="currentState === 'app' && !suppressTopbar" :user="user"></top-bar>
+    <div v-if="currentState === 'loading'" class="ui very padded basic center aligned loading-overlay segment">
         <div>
             <img class="ui small image" src='../static/img/croud_logo_new.svg' />
         </div>
     </div>
-    <slot name="login" v-else-if="!user.id">
+    <slot name="login" v-else-if="currentState === 'login'">
         <login />
     </slot>
     <slot v-else name="custom-layout">
@@ -95,9 +95,9 @@ export default {
             user: 'universal/user',
             jwt: 'universal/jwt',
             root: 'universal/root',
-            loading: 'universal/loading',
             globalPermission: 'universal/globalPermission',
             expanded: 'universal/expandedNav',
+            currentState: 'universal/currentState',
         }),
     },
 

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,24 @@
+import { Machine } from 'xstate'
+
+export default Machine({
+    id: 'universal',
+    initial: 'loading',
+    states: {
+        loading: {
+            on: {
+                LOGOUT: 'login',
+                SHOW_APP: 'app',
+            },
+        },
+        login: {
+            on: {
+                LOGIN: 'app',
+            },
+        },
+        app: {
+            on: {
+                LOGOUT: 'login',
+            },
+        },
+    },
+})

--- a/test/unit/specs/App.spec.js
+++ b/test/unit/specs/App.spec.js
@@ -2,13 +2,15 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import VueI18n from 'vue-i18n'
 
-// import _ from 'lodash'
+import { cloneDeep } from 'lodash'
 import localforage from 'localforage'
 import localstorage from 'localstorage'
 // import axios from 'axios'
 
+import universal from '../../../src/store/modules/universal'
+import notifications from '../../../src/store/modules/notifications'
 import App from '../../../src/App'
-import Store from '../../../src/store'
+// import Store from '../../../src/store'
 import messages from '../../../src/il8n'
 
 Vue.use(VueI18n)
@@ -17,6 +19,13 @@ const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjVlNjE0OWQyMjgzYzBhZmE
 const i18n = new VueI18n({
     locale: 'en',
     messages,
+})
+
+const vuexFactory = () => new Vuex.Store({
+    modules: {
+        universal: cloneDeep(universal),
+        notifications: cloneDeep(notifications),
+    },
 })
 
 describe('App.vue', () => {
@@ -30,14 +39,16 @@ describe('App.vue', () => {
             components: {
                 App,
             },
-            store: Store,
+            store: vuexFactory(),
             render: h => h(App),
         }).$mount()
     })
 
-    test('should bounce to login page if no JWT exists', () => {
-        expect($vm.$el).toMatchSnapshot()
-        expect(typeof $vm).toBe('object')
+    test('should bounce to login page if no JWT exists', async () => {
+        await $vm.$store.dispatch('universal/$init').then(() => {
+            expect($vm.$el).toMatchSnapshot()
+            expect(typeof $vm).toBe('object')
+        })
     })
 
     test('should carry on loading with jwt but no cached data', async () => {
@@ -69,7 +80,7 @@ describe('App.vue', () => {
                 components: {
                     App,
                 },
-                store: Store,
+                store: vuexFactory(),
                 render: h => h(App, {
                     props: {
                         suppressTopbar: true,
@@ -96,7 +107,7 @@ describe('App.vue', () => {
                 components: {
                     App,
                 },
-                store: Store,
+                store: vuexFactory(),
                 render: h => h(App, {
                     props: {
                         suppressTopbar: true,

--- a/test/unit/specs/Universal.spec.js
+++ b/test/unit/specs/Universal.spec.js
@@ -17,8 +17,8 @@ describe('Universal Store Module', () => {
         })
 
         it('should start in a loading state', () => {
-            expect(typeof Universal.state.loading).toEqual('boolean')
-            expect(Universal.state.loading).toEqual(true)
+            expect(typeof Universal.state.currentState).toEqual('string')
+            expect(Universal.state.currentState).toEqual('loading')
         })
     })
 
@@ -31,8 +31,8 @@ describe('Universal Store Module', () => {
         })
 
         it('should stop loading when STOP_LOADING mutation is called', () => {
-            $store.commit('STOP_LOADING')
-            expect($store.state.loading).toEqual(false)
+            $store.commit('UPDATE_CURRENT_STATE', 'app')
+            expect($store.state.currentState).toEqual('app')
         })
 
         it('should update the user object', () => {
@@ -119,7 +119,7 @@ describe('Universal Store Module', () => {
         describe('$init', () => {
             it('should stop loading without jwt', () => {
                 $store.dispatch('$init')
-                expect($store.state.loading).toBe(false)
+                expect($store.state.currentState).toBe('login')
             })
 
             it('should keep loading with JWT but no user cache', () => {
@@ -127,7 +127,7 @@ describe('Universal Store Module', () => {
                 $store.commit('UPDATE_JWT')
 
                 $store.dispatch('$init')
-                expect($store.state.loading).toBe(true)
+                expect($store.state.currentState).toBe('loading')
             })
 
             it('should stop loading if user data is in the cache', async () => {
@@ -140,7 +140,7 @@ describe('Universal Store Module', () => {
                 $store.commit('UPDATE_JWT')
 
                 await $store.dispatch('$init').then(() => {
-                    expect($store.state.loading).toBe(false)
+                    expect($store.state.currentState).toBe('app')
                 })
             })
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11203,6 +11203,10 @@ xmlhttprequest@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
+xstate@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-3.1.1.tgz#7d6b5f77a35547ec21269ac8f67e4ad60fd25fbe"
+
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"


### PR DESCRIPTION
Moving croud-layout to use a state machine to dictate what is visible in the current layout rather than using adhoc store values such as whether the user.id exists.

A state machine will govern the transitions and stop ones that aren't allowed and so will prevent edge cases where things might be loading out of order

This would fix https://github.com/CroudTech/croud-layout/issues/30

This may cause some breaking changes to how logging out would work in custom layouts, ie client portal.