### PR TITLE
rename legacy login/auth route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "croud-layout",
   "main": "src/plugin.js",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A Vue.js project",
   "author": "Brock <brock.reece@croud.co.uk>",
   "private": false,

--- a/src/Login/mixin.js
+++ b/src/Login/mixin.js
@@ -153,7 +153,7 @@ export default {
                 this.$emit('login')
 
                 if (this.legacyAuth) {
-                    this.$httpLegacy.post('/login/auth/', {
+                    this.$httpLegacy.post('/authenticate/', {
                         authToken: response.data.jwt,
                     })
                 }
@@ -184,7 +184,7 @@ export default {
             window.addEventListener('message', (event) => {
                 localStorage.setItem('jwt', event.data.access_token)
                 if (this.legacyAuth) {
-                    this.$httpLegacy.post('/login/auth/', {
+                    this.$httpLegacy.post('/authenticate/', {
                         authToken: event.data.access_token,
                     })
                 }

--- a/src/components/UserSwitcher.vue
+++ b/src/components/UserSwitcher.vue
@@ -203,7 +203,7 @@
                     })
 
                     if (this.legacyAuth) {
-                        this.$httpLegacy.post('/login/auth/', { authToken: response.data.jwt.access_token })
+                        this.$httpLegacy.post('/authenticate/', { authToken: response.data.jwt.access_token })
                             .then(this.redirectAfterLogin)
                     }
                 })
@@ -226,7 +226,7 @@
                     this.loading = false
                 })
                 if (this.legacyAuth) {
-                    this.$httpLegacy.post('/login/auth/', { authToken: localStorage.getItem('root') })
+                    this.$httpLegacy.post('/authenticate/', { authToken: localStorage.getItem('root') })
                         .then(this.redirectAfterLogin)
                 }
             },


### PR DESCRIPTION
This rewrites the route to hit legacy. The reason for this is to set the route `/login` on the mono repo redirects any route with that prefix back to the monorepo login SPA, resulting in the predicted endless redirect. The simplest solution is simply to rewrite the route on legacy.