### PR TITLE
Feature/jwt safe decode

### DIFF
--- a/src/store/jwtSafeDecode.js
+++ b/src/store/jwtSafeDecode.js
@@ -1,0 +1,9 @@
+import jwtDecode from 'jwt-decode'
+
+export default (jwt) => {
+    try {
+        return jwt ? jwtDecode(jwt) : {}
+    } catch (e) {
+        return {}
+    }
+}

--- a/src/store/localForage.js
+++ b/src/store/localForage.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import localforage from 'localforage'
-import jwtDecode from 'jwt-decode'
+import jwtDecode from './jwtSafeDecode'
 
 const jwt = localStorage.getItem('jwt') ? jwtDecode(localStorage.getItem('jwt')) : {}
 const rootJwt = localStorage.getItem('root') ? jwtDecode(localStorage.getItem('root')) : {}

--- a/src/store/modules/universal.js
+++ b/src/store/modules/universal.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import jwtDecode from 'jwt-decode'
 import localforage from 'localforage'
+import jwtDecode from '../jwtSafeDecode'
 import { rootStore } from '../localForage'
 
 export default {
@@ -97,7 +97,7 @@ export default {
 
         $init: async (context) => {
             context.state.loading = true
-            if (!localStorage.getItem('jwt')) {
+            if (!localStorage.getItem('jwt') || !context.state.jwt.sub) {
                 context.commit('STOP_LOADING')
                 return
             }

--- a/test/unit/specs/__snapshots__/jwtSafeDecode.spec.js.snap
+++ b/test/unit/specs/__snapshots__/jwtSafeDecode.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jwtSafeDecode valid token 1`] = `
+Object {
+  "aud": "gateway-ireland",
+  "exp": 1528035230,
+  "iat": 1527776031,
+  "jti": "1b86340fa1c959a069f550f42402d4419818b167b960fd6d159eb84881e2b2957683045cf75210d4",
+  "nbf": 1527776031,
+  "scopes": Array [],
+  "sub": "2765",
+}
+`;

--- a/test/unit/specs/jwtSafeDecode.spec.js
+++ b/test/unit/specs/jwtSafeDecode.spec.js
@@ -1,0 +1,15 @@
+import jwtDecode from '../../../src/store/jwtSafeDecode'
+
+describe('jwtSafeDecode', () => {
+    test('valid token', () => {
+        expect(jwtDecode('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjFiODYzNDBmYTFjOTU5YTA2OWY1NTBmNDI0MDJkNDQxOTgxOGIxNjdiOTYwZmQ2ZDE1OWViODQ4ODFlMmIyOTU3NjgzMDQ1Y2Y3NTIxMGQ0In0.eyJhdWQiOiJnYXRld2F5LWlyZWxhbmQiLCJqdGkiOiIxYjg2MzQwZmExYzk1OWEwNjlmNTUwZjQyNDAyZDQ0MTk4MThiMTY3Yjk2MGZkNmQxNTllYjg0ODgxZTJiMjk1NzY4MzA0NWNmNzUyMTBkNCIsImlhdCI6MTUyNzc3NjAzMSwibmJmIjoxNTI3Nzc2MDMxLCJleHAiOjE1MjgwMzUyMzAsInN1YiI6IjI3NjUiLCJzY29wZXMiOltdfQ.pAFuOxJKUnkvXu_fop56LHuawgb_DNn0eQrmxOhxp1hj8WrvsWeOUXjEAJWRg_7cXNGRYKjrMxs7WS-EijfBniD5dvmOBOhr49Jgdt-nGbfRmTpvMaj5wxBUvKg6ZCroij18S4RGnFFaWKVFhLKuaxVPMN1MEWWKVYhvK8cijrcErS1YTdA_93a6c35U3hxbZhmjFfupQfHwCNM4sxDP9XaAAK4hEUD4AObQ28XZGeGn9S8XC_UzFp98d5Bx5Y8GRab0ztuVdzUzN9zKp7WBjLvhMZOOtvvhg0aKG5QyEfTsa9tH0WbjBg12xBBvzdh1OVXGjePVl1VTsXts2cewQY-jR0t5nl8bpT_CDtM8DQD8dhR53daRXEd7lIyfLIoBE__6TTFf1fy4FFcrf51t9Eyl8596T7qp9PGtjVCvHOzaKL284WNfRuv_KglXIF1rr4CxSIXo63ZVLUmN-PfLBNVjDVZ8ZAAvd1Olwnuzw49hy6uK2HluX7HngxcZQHI1xyw6sGA4NIS11Srum8vFAHUXxdsq8dtaGnpK2b1-I_om3JxZ4LW_uKr0nzhvwOxiBgcipmVd3ziLB9DgZRfQKx-OohE_S3r-0v1R6cxfO0YZY_b93H61xmCRYz5lWDEhWt8SJ7Lg7XeCPNLT5Zyc0WQNdavwEt7WK-P9KAKCiPo')).toMatchSnapshot()
+    })
+
+    test('invalid token', () => {
+        expect(jwtDecode('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjFiODYzNDBmYTFjOTU5YTA2OWY1NTBmNDI0MDJkNDQxOTgxOGIxNjdiOTYwZmQ2ZDE1OWViODQ4ODFlMmIyOTU3NjgzMDQ1Y2Y3NTIxMGQ0In0')).toEqual({})
+    })
+
+    test('empty token', () => {
+        expect(jwtDecode('')).toEqual({})
+    })
+})


### PR DESCRIPTION
This addresses issue in Jira ticket CC-1308

The error seemed to be that the JWT token was malformed, croud-layout didn't deal with this gracefully so I have added a wrapper for the jwt-decode lib that catches errors like this and returns an empty object, as if no JWT is present

Complete with full test coverage