### PR TITLE
Add local time to the notifications

### DIFF
--- a/src/components/notifications/Notifications.vue
+++ b/src/components/notifications/Notifications.vue
@@ -8,7 +8,7 @@
                             {{ notification.name }}
                         </div>
                         <div class="item">
-                            <small>{{ notification.deliver_at.date | moment('ll') }}</small>
+                            <small>{{ $moment.utc(notification.deliver_at.date).local().format('ll H:m') }}</small>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
As requested in CC-1499, this adds a local timestamp to the notifications.
Awaiting confirmation from product on format.