### PR TITLE
Add leading zeros to the hour and minute format in the notifications

### DIFF
--- a/src/components/notifications/Notifications.vue
+++ b/src/components/notifications/Notifications.vue
@@ -8,7 +8,7 @@
                             {{ notification.name }}
                         </div>
                         <div class="item">
-                            <small>{{ $moment.utc(notification.deliver_at.date).local().format('ll H:m') }}</small>
+                            <small>{{ $moment.utc(notification.deliver_at.date).local().format('ll HH:mm') }}</small>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
As reported by Product, the date format in the notifications was missing leading zeros for the hours and minutes.